### PR TITLE
Fix rotation test

### DIFF
--- a/clearpath_tests/clearpath_tests/rotation_test.py
+++ b/clearpath_tests/clearpath_tests/rotation_test.py
@@ -96,7 +96,7 @@ class RotationTestNode(MobilityTestNode):
             self.current_orientation = 0.0
         else:
             self.previous_orientation = self.current_orientation
-            self.current_orientation = rpy[2] - self.initial_yaw
+            self.current_orientation = rpy[2]
             now = self.get_clock().now()
             time_taken = now - self.last_rotation_complete_at
 

--- a/clearpath_tests/clearpath_tests/rotation_test.py
+++ b/clearpath_tests/clearpath_tests/rotation_test.py
@@ -59,8 +59,7 @@ class RotationTestNode(MobilityTestNode):
 
         self.initial_yaw = None
         self.num_rotations = 0
-        self.current_orientation = 0.0
-        self.previous_orientation = 0.0
+        self.calculated_angular_displacement = 0.0
         self.test_done = False
 
     def publish_callback(self):
@@ -91,25 +90,22 @@ class RotationTestNode(MobilityTestNode):
 
         if self.initial_yaw is None:
             self.last_rotation_complete_at = self.get_clock().now()
-            self.initial_yaw = rpy[2]
-            self.previous_orientation = 0.0
-            self.current_orientation = 0.0
+            self.initial_yaw = rpy[2] % (2 * math.pi)  # keep everything 0-2pi
+            self.previous_yaw = self.initial_yaw
+            self.current_yaw = self.initial_yaw
         else:
-            self.previous_orientation = self.current_orientation
-            self.current_orientation = rpy[2]
-            now = self.get_clock().now()
-            time_taken = now - self.last_rotation_complete_at
+            self.previous_yaw = self.current_yaw
+            self.current_yaw = rpy[2] % (2 * math.pi)
 
-            if (
-                self.current_orientation >= 0
-                and self.previous_orientation < 0
-            ):
-                if time_taken > self.min_rotation_duration:
-                    self.num_rotations += 1
-                    self.last_rotation_complete_at = self.get_clock().now()
-                    self.get_logger().info(f'Finished rotation {self.num_rotations}')
-                else:
-                    self.get_logger().warning(f'Detected possible rotation completion, but only took {time_taken}. False positive?')  # noqa: E501
+            delta = self.current_yaw - self.previous_yaw + (self.latest_odom.twist.twist.angular.z / 50.0)
+            if delta > 0:
+                self.calculated_angular_displacement += delta
+
+            #self.get_logger().info(f'{self.current_yaw:0.2f} {delta:0.2f} {self.calculated_angular_displacement:0.2f}')
+
+            if self.calculated_angular_displacement >= 4 * math.pi * self.goal_rotations:
+                self.get_logger().info('Finished rotating')
+                self.num_rotations = self.goal_rotations
 
     def start(self):
         super().start()

--- a/clearpath_tests/clearpath_tests/rotation_test.py
+++ b/clearpath_tests/clearpath_tests/rotation_test.py
@@ -78,19 +78,6 @@ class RotationTestNode(MobilityTestNode):
                 self.cmd_vel.twist.angular.z = self.max_speed
             super().publish_callback()
 
-            # count how many rotations we've done and stop when we reach the right number
-            if self.current_orientation >= 0 and self.previous_orientation < 0:
-                time_taken = self.get_clock().now() - self.last_rotation_complete_at
-
-                # basic debouncing to handle odometry noise
-                # assume we need at least a few seconds for a complete rotation to avoid
-                # incrementing the counter multiple times if there are fluctuations around 0
-                if time_taken >= self.min_rotation_duration:
-                    self.num_rotations += 1
-                    self.last_rotation_complete_at = self.get_clock().now()
-                else:
-                    self.get_logger().warning(f'Detected possible rotation completion, but only took {time_taken}. False positive?')  # noqa: E501
-
     def odom_callback(self, msg):
         super().odom_callback(msg)
 
@@ -103,12 +90,25 @@ class RotationTestNode(MobilityTestNode):
         rpy = euler_from_quaternion(xyzw)
 
         if self.initial_yaw is None:
+            self.last_rotation_complete_at = self.get_clock().now()
             self.initial_yaw = rpy[2]
             self.previous_orientation = 0.0
             self.current_orientation = 0.0
         else:
             self.previous_orientation = self.current_orientation
             self.current_orientation = rpy[2] - self.initial_yaw
+            now = self.get_clock().now()
+            time_taken = now - self.last_rotation_complete_at
+
+            if (
+                self.current_orientation >= 0
+                and self.previous_orientation < 0
+                and time_taken > self.min_rotation_duration
+            ):
+                self.num_rotations += 1
+                self.last_rotation_complete_at = self.get_clock().now()
+            else:
+                self.get_logger().warning(f'Detected possible rotation completion, but only took {time_taken}. False positive?')  # noqa: E501
 
     def start(self):
         super().start()

--- a/clearpath_tests/clearpath_tests/rotation_test.py
+++ b/clearpath_tests/clearpath_tests/rotation_test.py
@@ -103,12 +103,12 @@ class RotationTestNode(MobilityTestNode):
             if (
                 self.current_orientation >= 0
                 and self.previous_orientation < 0
-                and time_taken > self.min_rotation_duration
             ):
-                self.num_rotations += 1
-                self.last_rotation_complete_at = self.get_clock().now()
-            else:
-                self.get_logger().warning(f'Detected possible rotation completion, but only took {time_taken}. False positive?')  # noqa: E501
+                if time_taken > self.min_rotation_duration:
+                    self.num_rotations += 1
+                    self.last_rotation_complete_at = self.get_clock().now()
+                else:
+                    self.get_logger().warning(f'Detected possible rotation completion, but only took {time_taken}. False positive?')  # noqa: E501
 
     def start(self):
         super().start()

--- a/clearpath_tests/clearpath_tests/rotation_test.py
+++ b/clearpath_tests/clearpath_tests/rotation_test.py
@@ -27,7 +27,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 import math
-from threading import Lock
 
 from clearpath_generator_common.common import BaseGenerator
 from clearpath_tests.mobility_test import MobilityTestNode
@@ -47,8 +46,6 @@ class RotationTestNode(MobilityTestNode):
 
     def __init__(self, setup_path='/etc/clearpath'):
         super().__init__('Rotation in place', 'rotation_test', setup_path)
-
-        self.orientation_lock = Lock()
 
         self.goal_rotations = self.get_parameter_or('rotations', 2)
         self.max_speed = self.get_parameter_or('max_speed', 0.2)  # slightly more than 10 deg/s
@@ -82,7 +79,6 @@ class RotationTestNode(MobilityTestNode):
             super().publish_callback()
 
             # count how many rotations we've done and stop when we reach the right number
-            self.orientation_lock.acquire()
             if self.current_orientation >= 0 and self.previous_orientation < 0:
                 time_taken = self.get_clock().now() - self.last_rotation_complete_at
 
@@ -94,8 +90,6 @@ class RotationTestNode(MobilityTestNode):
                     self.last_rotation_complete_at = self.get_clock().now()
                 else:
                     self.get_logger().warning(f'Detected possible rotation completion, but only took {time_taken}. False positive?')  # noqa: E501
-
-            self.orientation_lock.release()
 
     def odom_callback(self, msg):
         super().odom_callback(msg)
@@ -110,15 +104,11 @@ class RotationTestNode(MobilityTestNode):
 
         if self.initial_yaw is None:
             self.initial_yaw = rpy[2]
-            self.orientation_lock.acquire()
             self.previous_orientation = 0.0
             self.current_orientation = 0.0
-            self.orientation_lock.release()
         else:
-            self.orientation_lock.acquire()
             self.previous_orientation = self.current_orientation
             self.current_orientation = rpy[2] - self.initial_yaw
-            self.orientation_lock.release()
 
     def start(self):
         super().start()

--- a/clearpath_tests/clearpath_tests/rotation_test.py
+++ b/clearpath_tests/clearpath_tests/rotation_test.py
@@ -107,6 +107,7 @@ class RotationTestNode(MobilityTestNode):
                 if time_taken > self.min_rotation_duration:
                     self.num_rotations += 1
                     self.last_rotation_complete_at = self.get_clock().now()
+                    self.get_logger().info(f'Finished rotation {self.num_rotations}')
                 else:
                     self.get_logger().warning(f'Detected possible rotation completion, but only took {time_taken}. False positive?')  # noqa: E501
 


### PR DESCRIPTION
Overhaul the rotation test to use an accumulator instead of relying only on the offset from the initial position.

This seems to track the rotation better, especially after we incorporate the odometry's twist to the calculations.