### PR TITLE
Remove rotation test

### DIFF
--- a/clearpath_tests/clearpath_tests/all_tests.py
+++ b/clearpath_tests/clearpath_tests/all_tests.py
@@ -48,11 +48,15 @@ from clearpath_tests import (
     diagnostic_test,
     drive_test,
     estop_test,
-    # blocked waiting for firmware changes -- fan_test,
+    # blocked waiting for firmware changes
+    # fan_test,
     imu_test,
     light_test,
     mcu_test,
-    rotation_test,
+    # disabled for now as its accuracy isn't up to par and it
+    # frequently causes the motors to self-throttle on high-traction
+    # surfaces
+    # rotation_test,
     wifi_test,
 )
 from clearpath_tests.test_node import (
@@ -82,7 +86,7 @@ class TestingNode(Node):
         ]
 
         self.driving_tests = [
-            rotation_test.RotationTestNode(self.setup_path),
+            # rotation_test.RotationTestNode(self.setup_path),
             drive_test.DriveTestNode(self.setup_path),
         ]
 


### PR DESCRIPTION
The rotation test still isn't performing well according to the production team. After discussion with Justin, we've agreed that it's not worth sinking more time into.

Apparently even on Noetic the rotation tests for the A200 were not reliable. There's nothing especially useful being tested here that isn't covered by the IMU and linear driving tests anyway, so I don't think we're losing anything major by removing it.